### PR TITLE
Disallow robots to use youtube-dl at /lite/music/*

### DIFF
--- a/anyaudio/views/generic.py
+++ b/anyaudio/views/generic.py
@@ -42,11 +42,19 @@ def lite_search():
 @record_request
 def serve_music_lite(id):
     video = {}
-    url = get_download_link_youtube(
-        id, 'webm[abr<=64]/webm[abr<=80]/m4a[abr<=64]/[abr<=96]/m4a')
-    stream_url = url_for('stream_handler', url=encode_data(get_key(), url=url))
-    url = get_download_link_youtube(id, 'm4a/bestaudio')
-    download_url = url_for('download_file', url=encode_data(get_key(), url=url))
+    if 'bot' in request.user_agent.string.lower():
+        url = ""
+        stream_url = ""
+        download_url = ""
+    else:
+        url = get_download_link_youtube(
+            id, 'webm[abr<=64]/webm[abr<=80]/m4a[abr<=64]/[abr<=96]/m4a')
+        stream_url = url_for('stream_handler', url=encode_data(get_key(),
+                                                               url=url))
+        url = get_download_link_youtube(id, 'm4a/bestaudio')
+        download_url = url_for(
+            'download_file', url=encode_data(get_key(), url=url))
+
     video['stream_url'] = stream_url
     video['download_url'] = download_url
     video['suggestions'] = get_suggestions(id)
@@ -71,7 +79,8 @@ def terms_of_use():
 def explore():
     search_query = request.args.get('q')
     if search_query:
-        search_query = '"{0}"'.format(search_query.replace('\"', '\\\"').strip())
+        search_query = '"{0}"'.format(
+            search_query.replace('\"', '\\\"').strip())
     else:
         search_query = '""'
 


### PR DESCRIPTION
By checking for 'bot' in User-Agent string

Example - 
```html
$ http http://127.0.0.1:5000/lite/music/zs-UtDZQ4Uo  'User-Agent:Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)'
HTTP/1.1 200 OK
Connection: close
Content-Length: 14536
Content-Type: text/html; charset=utf-8
Date: Sat, 20 May 2017 06:22:41 GMT
Server: gunicorn/19.7.1

<!--
  source
  https://github.com/aviaryan/youtube-mp3-server
-->
<!DOCTYPE html>
<html>
<head>
    ...
</head>
<body>
    ...
    <audio controls src="" href="">
        Audio Player not supported.
    </audio>
    <div>
        <a href="">Download</a>
    </div>
    <h3>Related Videos - </h3>
    ...
</body>
</html>
```